### PR TITLE
Use Nuxt 1.0 render API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ npm install # or yarn install*[see note below]
 
 *Note: Due to a bug in yarn's engine version detection code if you are
 using a prerelease version of Node (i.e. v7.6.0-rc.1) you will need to either:
+
   1. Use `npm install`
   2. Run `yarn` with a standard release of Node and then switch back
 
@@ -39,7 +40,3 @@ using a prerelease version of Node (i.e. v7.6.0-rc.1) you will need to either:
 - [KoaJS license](https://github.com/koajs/koa/blob/master/LICENSE)
 - [NuxtJS license](https://github.com/nuxt/nuxt.js/blob/master/LICENSE.md)
 - [VueJS license](https://github.com/vuejs/vue/blob/master/LICENSE)
-
-## Credits
-
-- [@detrohutt](https://github.com/detrohutt) for making the option of choosing between Koa 1.x and 2.x (PR [#2](https://github.com/nuxt/koa/pull/2))

--- a/meta.js
+++ b/meta.js
@@ -3,11 +3,7 @@ module.exports = {
     raw: function(options) {
       return options.fn(this)
     },
-    koaSemver: function() {
-      return this.koaVersion === '1.x' ? '^1.2.5' : '^2.0.0'
-    },
     ifBabel: function(options) {
-      if (this.koaVersion !== '2.x') return ''
       var nodeMajMin = process.version.match(/v(\d*).(\d*)./)
       var semMaj = Number(nodeMajMin[1])
       var semMin = Number(nodeMajMin[2])
@@ -30,13 +26,6 @@ module.exports = {
     author: {
       'type': 'string',
       'message': 'Author'
-    },
-    koaVersion: {
-      'type': 'list',
-      'required': true,
-      'message': 'Koa version',
-      'choices': ['1.x', '2.x'],
-      'default': 0
     }
   },
   completeMessage: '{{#inPlace}}To get started:\n\n  npm install # Or yarn\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}\n  npm install # Or yarn\n  npm run dev{{/inPlace}}'

--- a/template/layouts/default.vue
+++ b/template/layouts/default.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import MyFooter from '~components/Footer.vue'
+import MyFooter from '../components/Footer.vue'
 
 export default {
   components: {

--- a/template/package.json
+++ b/template/package.json
@@ -12,9 +12,9 @@
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore ."
   },
   "dependencies": {
-    "cross-env": "^5.0.0",
-    "koa": "{{ koaSemver }}",
-    "nuxt": "~1.0.0-alpha1",
+    "cross-env": "^5.0.1",
+    "koa": "^2.3.0",
+    "nuxt": "^1.0.0-rc3",
     "source-map-support": "^0.4.15"
   },
   "devDependencies": {

--- a/template/server/index.js
+++ b/template/server/index.js
@@ -1,34 +1,45 @@
 import Koa from 'koa'
-import Nuxt from 'nuxt'
+import { Nuxt, Builder } from 'nuxt'
 
 const app = new Koa()
 const host = process.env.HOST || '127.0.0.1'
 const port = process.env.PORT || 3000
 
-// Start nuxt.js
-async function start () {
-  // Import and Set Nuxt.js options
-  let config = require('../nuxt.config.js')
-  config.dev = !(app.env === 'production')
-  // Instanciate nuxt.js
-  const nuxt = await new Nuxt(config)
-  // Build in development
-  if (config.dev) {
-    try {
-      await nuxt.build()
-    } catch (e) {
-      console.error(e) // eslint-disable-line no-console
-      process.exit(1)
-    }
-  }
+// Import and Set Nuxt.js options
+let config = require('../nuxt.config.js')
+config.dev = !(app.env === 'production')
 
-  app.use(async (ctx, next) => {
-  ctx.status = 200 // koa defaults to 404 when it sees that status is unset
-    await nuxt.render(ctx.req, ctx.res)
+// Instantiate nuxt.js
+const nuxt = new Nuxt(config)
+
+// Build in development
+if (config.dev) {
+  const builder = new Builder(nuxt)
+  builder.build().catch(e => {
+    console.error(e) // eslint-disable-line no-console
+    process.exit(1)
   })
-
-  app.listen(port, host)
-  console.log('Server listening on ' + host + ':' + port) // eslint-disable-line no-console
 }
 
-start()
+app.use(async ctx => {
+  ctx.status = 200 // koa defaults to 404 when it sees that status is unset
+
+  return new Promise((resolve, reject) => {
+    const mockedResponse = {
+      __proto__: ctx.res,
+      end() {
+        ctx.res.end.apply(ctx.res, arguments)
+        // nuxt.render doesn't call next() on successful render,
+        // resolve promise manually
+        resolve()
+      }
+    }
+    nuxt.render(ctx.req, mockedResponse, promise => {
+      // nuxt.render passes a rejected promise into callback on error.
+      promise.then(resolve).catch(reject)
+    })
+  })
+})
+
+app.listen(port, host)
+console.log('Server listening on ' + host + ':' + port) // eslint-disable-line no-console


### PR DESCRIPTION
This switches to the new Nuxt 1.0 render API.

This also drops support for Koa 1.x (which was broken anyway since c0b51a4071b1c7cc475ff198a5ece3d3a63810eb).