### PR TITLE
Turn callback to simple function (not async)

### DIFF
--- a/template/server/index.js
+++ b/template/server/index.js
@@ -21,7 +21,7 @@ if (config.dev) {
   })
 }
 
-app.use(async ctx => {
+app.use(ctx => {
   ctx.status = 200 // koa defaults to 404 when it sees that status is unset
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
There is Promise instance is returned from this function, so we not need make the function async