### PR TITLE
Fix koa-template with nuxt@1.0.0-rc3

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "cross-env": "^5.0.1",
+    "es6-promise": "^4.1.1",
     "koa": "^2.3.0",
     "nuxt": "^1.0.0-rc3",
     "source-map-support": "^0.4.15"

--- a/template/server/index.js
+++ b/template/server/index.js
@@ -23,18 +23,8 @@ if (config.dev) {
 
 app.use(async ctx => {
   ctx.status = 200 // koa defaults to 404 when it sees that status is unset
-
   return new Promise((resolve, reject) => {
-    const mockedResponse = {
-      __proto__: ctx.res,
-      end() {
-        ctx.res.end.apply(ctx.res, arguments)
-        // nuxt.render doesn't call next() on successful render,
-        // resolve promise manually
-        resolve()
-      }
-    }
-    nuxt.render(ctx.req, mockedResponse, promise => {
+    nuxt.render(ctx.req, ctx.res, promise => {
       // nuxt.render passes a rejected promise into callback on error.
       promise.then(resolve).catch(reject)
     })


### PR DESCRIPTION
When running a fresh install of the koa-template I encountered some errors:

1. `es6-promise/auto` was being required but not found
2. Running `yarn build && yarn start` seemed to start the server properly but I couldn't load any page of the app which just seemed to load indefinitely (#19)

Here's what I did to try and fix those issues:

1. Add `es6-promise` in the template's dependencies
2. Instead of passing the `mockedResponse` to `nuxt.render()`, pass it the original `ctx.res` from Koa

I'm not too familiar with Node.js servers yet so I couldn't really understand the idea behind this `mockedResponse` object, there's probably a better fix for this one.