### PR TITLE
Rework Koa middleware promise to use HTTP events

### DIFF
--- a/template/server/index.js
+++ b/template/server/index.js
@@ -21,20 +21,13 @@ if (config.dev) {
   })
 }
 
-app.use(async ctx => {
+app.use(ctx => {
   ctx.status = 200 // koa defaults to 404 when it sees that status is unset
 
   return new Promise((resolve, reject) => {
-    const mockedResponse = {
-      __proto__: ctx.res,
-      end() {
-        ctx.res.end.apply(ctx.res, arguments)
-        // nuxt.render doesn't call next() on successful render,
-        // resolve promise manually
-        resolve()
-      }
-    }
-    nuxt.render(ctx.req, mockedResponse, promise => {
+    ctx.res.on('close', resolve)
+    ctx.res.on('finish', resolve)
+    nuxt.render(ctx.req, ctx.res, promise => {
       // nuxt.render passes a rejected promise into callback on error.
       promise.then(resolve).catch(reject)
     })


### PR DESCRIPTION
This is a rework of #17. This fixes #19 and supersedes #18 and #20.