### PR TITLE
Simplify Koa middleware

### DIFF
--- a/template/server/index.js
+++ b/template/server/index.js
@@ -19,17 +19,11 @@ async function start () {
     await builder.build()
   }
 
-  app.use(async (ctx, next) => {
-    await next()
-    ctx.status = 200 // koa defaults to 404 when it sees that status is unset
-    return new Promise((resolve, reject) => {
-      ctx.res.on('close', resolve)
-      ctx.res.on('finish', resolve)
-      nuxt.render(ctx.req, ctx.res, promise => {
-        // nuxt.render passes a rejected promise into callback on error.
-        promise.then(resolve).catch(reject)
-      })
-    })
+  app.use(ctx => {
+    ctx.status = 200
+    ctx.respond = false // Mark request as handled for Koa
+    ctx.req.ctx = ctx // This might be useful later on, e.g. in nuxtServerInit or with nuxt-stash
+    nuxt.render(ctx.req, ctx.res)
   })
 
   app.listen(port, host)


### PR DESCRIPTION
The middleware that I submitted in #21 was overcomplicated. Koa server has a special [ctx.respond = false](https://koajs.com/#ctx-respond) mode which is intended for this very case (handle node request by an external connect-style middleware).

This PR simplifies things. I am using this code in production.